### PR TITLE
Redirect admin to admin/shipments upon login.

### DIFF
--- a/app/assets/javascripts/application/auth/controllers/SessionsCtrl.js
+++ b/app/assets/javascripts/application/auth/controllers/SessionsCtrl.js
@@ -23,7 +23,7 @@ dtracker.controller('SessionCtrl', ['$rootScope', '$scope', '$auth', '$location'
     $rootScope.flash = flash;
     $rootScope.flash.setMessage('You successfully signed in.');
     if (user.role === "admin") {
-      $location.path('/admin/statistics');
+      $location.path('/admin/shipments');
     } else {
       $location.path('/shipments');
     }


### PR DESCRIPTION
Task:
1. Make the ‘Admin’ page the home page upon login ( instead of the ‘Order static’ page)
